### PR TITLE
🧪 [testing improvement] Add unit tests for simpleLiteralConverters

### DIFF
--- a/src/test/core/converters/simpleLiteralConverters.test.ts
+++ b/src/test/core/converters/simpleLiteralConverters.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import * as ts from 'typescript';
+import { convertStringLiterals, convertNoSubstitutionTemplateLiterals } from '../../../core/converters/simpleLiteralConverters';
+import { StringType } from '../../../core/models/constants';
+
+suite('simpleLiteralConverters', function () {
+
+  suite('convertStringLiterals', function () {
+    test('should correctly identify StringLiteral nodes', function () {
+      const nodes = [
+        { kind: ts.SyntaxKind.StringLiteral, getText: () => "'test'" } as unknown as ts.Node,
+        { kind: ts.SyntaxKind.NoSubstitutionTemplateLiteral, getText: () => '`test`' } as unknown as ts.Node,
+      ];
+
+      const result = convertStringLiterals(nodes, [StringType.DOUBLE_QUOTE]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].node, nodes[0]);
+    });
+
+    test('should convert single-quoted string to double-quoted string', function () {
+      const nodes = [
+        { kind: ts.SyntaxKind.StringLiteral, getText: () => "'test'" } as unknown as ts.Node,
+      ];
+
+      const result = convertStringLiterals(nodes, [StringType.DOUBLE_QUOTE]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].replacement, '"test"');
+    });
+
+    test('should convert double-quoted string to template literal', function () {
+      const nodes = [
+        { kind: ts.SyntaxKind.StringLiteral, getText: () => '"test"' } as unknown as ts.Node,
+      ];
+
+      const result = convertStringLiterals(nodes, [StringType.TEMPLATE_LITERAL]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].replacement, '`test`');
+    });
+  });
+
+  suite('convertNoSubstitutionTemplateLiterals', function () {
+    test('should correctly identify NoSubstitutionTemplateLiteral nodes', function () {
+      const nodes = [
+        { kind: ts.SyntaxKind.StringLiteral, getText: () => "'test'" } as unknown as ts.Node,
+        { kind: ts.SyntaxKind.NoSubstitutionTemplateLiteral, getText: () => '`test`' } as unknown as ts.Node,
+      ];
+
+      const result = convertNoSubstitutionTemplateLiterals(nodes, [StringType.DOUBLE_QUOTE]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].node, nodes[1]);
+    });
+
+    test('should inline line breaks when converting template literal to single-quoted string', function () {
+      const nodes = [
+        {
+          kind: ts.SyntaxKind.NoSubstitutionTemplateLiteral,
+          getText: () => '`line1\nline2`'
+        } as unknown as ts.Node,
+      ];
+
+      const result = convertNoSubstitutionTemplateLiterals(nodes, [StringType.SINGLE_QUOTE]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].replacement, "'line1\\nline2'");
+    });
+
+    test('should convert template literal to double-quoted string', function () {
+      const nodes = [
+        { kind: ts.SyntaxKind.NoSubstitutionTemplateLiteral, getText: () => '`test`' } as unknown as ts.Node,
+      ];
+
+      const result = convertNoSubstitutionTemplateLiterals(nodes, [StringType.DOUBLE_QUOTE]);
+
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0].replacement, '"test"');
+    });
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for simpleLiteralConverters.
📊 **Coverage:** What scenarios are now tested:
- Correct identification of `ts.SyntaxKind.StringLiteral` and `ts.SyntaxKind.NoSubstitutionTemplateLiteral` nodes.
- Conversion of single-quoted strings to double-quoted strings.
- Conversion of double-quoted strings to template literals.
- Inlining of line breaks when converting template literals to single-quoted strings.
- Conversion of template literals to double-quoted strings.
✨ **Result:** The improvement in test coverage for core literal conversion logic.

---
*PR created automatically by Jules for task [7351048857993063815](https://jules.google.com/task/7351048857993063815) started by @adiessl*