### PR TITLE
🧹 Simplify array concatenation with flatMap

### DIFF
--- a/src/core/converters/simpleLiteralConverterFactory.ts
+++ b/src/core/converters/simpleLiteralConverterFactory.ts
@@ -27,7 +27,6 @@ export function simpleLiteralConverterFactory(
 
     return nodes
       .filter(node => node.kind === filterSyntaxKind)
-      .map(node => convertNode(node))
-      .reduce((acc, cur) => acc.concat(cur), []);
+      .flatMap(node => convertNode(node));
   };
 }

--- a/src/core/converters/templateExpressionConverter.ts
+++ b/src/core/converters/templateExpressionConverter.ts
@@ -30,8 +30,7 @@ export function convertTemplateExpressions(nodes: ts.Node[], targets: StringType
         parts.push(processString(node.head.text));
 
         const spans = node.templateSpans
-          .map(processTemplateSpan)
-          .reduce((acc, cur) => acc.concat(cur), []);
+          .flatMap(processTemplateSpan);
 
         parts.push(...spans);
       }
@@ -49,6 +48,5 @@ export function convertTemplateExpressions(nodes: ts.Node[], targets: StringType
 
   return nodes
     .filter(node => node.kind === ts.SyntaxKind.TemplateExpression)
-    .map(node => convertNode(node))
-    .reduce((acc, cur) => acc.concat(cur), []);
+    .flatMap(node => convertNode(node));
 }


### PR DESCRIPTION
This change improves code maintainability and readability by replacing verbose array flattening patterns with the native `flatMap` method.

🎯 **What:** Replaced `.map(...).reduce((acc, cur) => acc.concat(cur), [])` with `.flatMap(...)`.
💡 **Why:** `flatMap` is more concise, easier to read, and generally more performant than the manual map-reduce-concat pattern. It is supported in the project's target environment (ES2020).
✅ **Verification:**
- Performed `grep` to identify all occurrences of the pattern.
- Applied changes to `templateExpressionConverter.ts` and `simpleLiteralConverterFactory.ts`.
- Verified file contents after modification using `read_file`.
- Received a positive code review.
✨ **Result:** Cleaner and more modern TypeScript code in the core converter logic.

---
*PR created automatically by Jules for task [5841317481242465826](https://jules.google.com/task/5841317481242465826) started by @adiessl*