### PR TITLE
🔒 [security fix] Move sensitive replacement text to diagnostic data

### DIFF
--- a/src/core/backtixCodeActionProvider.ts
+++ b/src/core/backtixCodeActionProvider.ts
@@ -225,7 +225,7 @@ export class BacktixCodeActionProvider implements vscode.CodeActionProvider {
     }
 
     const { start, end } = diagnostic.range;
-    const replacement = diagnostic.code as string;
+    const replacement = diagnostic.data as string;
 
     const firstRange = new vscode.Range(start, start.translate(0, 1));
     const lastRange = new vscode.Range(end.translate(0, -1), end);
@@ -244,7 +244,7 @@ export class BacktixCodeActionProvider implements vscode.CodeActionProvider {
     }
 
     const range = diagnostic.range;
-    const replacement = diagnostic.code as string;
+    const replacement = diagnostic.data as string;
 
     edit.replace(range, replacement);
   }

--- a/src/core/models/constants.ts
+++ b/src/core/models/constants.ts
@@ -11,5 +11,6 @@ export const stringTypeToQuote: { [type in StringType]: string } = {
 };
 
 export enum DiagnosticCodes {
-  ADD_PLACEHOLDER
+  ADD_PLACEHOLDER,
+  CONVERT_STRING
 }

--- a/src/core/utils/diagnostic.utils.ts
+++ b/src/core/utils/diagnostic.utils.ts
@@ -12,7 +12,8 @@ export function convertToDiagnostic(
   const range = getDocumentRange(textDocument, replacement.node);
 
   const diagnostic = new vscode.Diagnostic(range, messages[replacement.targetType], vscode.DiagnosticSeverity.Hint);
-  diagnostic.code = replacement.replacement;
+  diagnostic.code = DiagnosticCodes.CONVERT_STRING;
+  diagnostic.data = replacement.replacement;
 
   return diagnostic;
 }

--- a/src/test/utils/diagnostic.utils.test.ts
+++ b/src/test/utils/diagnostic.utils.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as ts from 'typescript';
+import { convertToDiagnostic } from '../../core/utils/diagnostic.utils';
+import { StringType, DiagnosticCodes } from '../../core/models/constants';
+import { NodeReplacement } from '../../core/models/nodeReplacement';
+
+suite('diagnostic.utils.test', function () {
+  test('convertToDiagnostic should use safe code and store replacement in data', function () {
+    const mockDocument: any = {
+      positionAt: (offset: number) => new vscode.Position(0, offset)
+    };
+
+    const mockNode: any = {
+      getStart: () => 0,
+      getEnd: () => 5
+    };
+
+    const replacement: NodeReplacement = {
+      node: mockNode as ts.Node,
+      targetType: StringType.TEMPLATE_LITERAL,
+      replacement: '`test`'
+    };
+
+    const messages = {
+      [StringType.TEMPLATE_LITERAL]: 'Convert to backticks',
+      [StringType.SINGLE_QUOTE]: 'Convert to single quotes',
+      [StringType.DOUBLE_QUOTE]: 'Convert to double quotes'
+    };
+
+    const diagnostic = convertToDiagnostic(mockDocument as vscode.TextDocument, replacement, messages);
+
+    assert.strictEqual(diagnostic.code, DiagnosticCodes.CONVERT_STRING, 'Diagnostic code should be CONVERT_STRING');
+    assert.strictEqual(diagnostic.data, '`test`', 'Diagnostic data should contain the replacement string');
+    assert.strictEqual(diagnostic.message, 'Convert to backticks');
+  });
+});


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
This patch addresses a sensitive data exposure vulnerability where user code (replacement strings) was stored in the `vscode.Diagnostic.code` field.

⚠️ **Risk:** The potential impact if left unfixed
The `code` field in a `vscode.Diagnostic` is often exposed to telemetry, external logs, and UI elements. Storing raw user code in this field could lead to accidental broadcast of sensitive information to third-party services or local logs.

🛡️ **Solution:** How the fix addresses the vulnerability
The fix moves the sensitive replacement text into the `vscode.Diagnostic.data` field, which is the recommended location for extension-internal payload data. A static, safe identifier `DiagnosticCodes.CONVERT_STRING` is now used for the `code` field, ensuring that only metadata is exposed.

---
*PR created automatically by Jules for task [11793977027420297208](https://jules.google.com/task/11793977027420297208) started by @adiessl*