### PR TITLE
🔒 Fix secret exposure in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,9 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Publish extension
-        run: npx vsce publish ${{ env.PACKAGE_VERSION }} --pat ${{ secrets.AZURE_DEVOPS_TOKEN }}
+        run: npx vsce publish ${{ env.PACKAGE_VERSION }}
+        env:
+          VSCE_PAT: ${{ secrets.AZURE_DEVOPS_TOKEN }}
 
       - name: Package extension
         run: npx vsce package --out ${{ env.RELEASE_NAME }}


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability where the Azure DevOps Token was passed as a command-line argument in the GitHub Actions workflow.
⚠️ **Risk:** Secrets passed as command-line arguments can be logged by the CI/CD system or observed in process lists, leading to potential unauthorized access if the logs are exposed.
🛡️ **Solution:** Updated the `.github/workflows/publish.yml` to pass the token via the `VSCE_PAT` environment variable, which is automatically picked up by `vsce` and safely handled by GitHub Actions.

---
*PR created automatically by Jules for task [11569894298042036167](https://jules.google.com/task/11569894298042036167) started by @adiessl*